### PR TITLE
force XML2JSON to use JSON::XS

### DIFF
--- a/apim-hooks/apim-hooks.pl
+++ b/apim-hooks/apim-hooks.pl
@@ -60,7 +60,7 @@ while (1) {
 
   my $frame = $stomp->receive_frame;
 
-  my $converter = XML::XML2JSON->new( 'force_array' => 1 );
+  my $converter = XML::XML2JSON->new( 'force_array' => 1, 'module' => 'JSON::XS' );
   # this seems to be undefined sometimes
   unless($frame->body){
     ERROR("caught empty message");


### PR DESCRIPTION
On a system that has both JSON::Syck and JSON::XS modules installed, XML2JSON prefers JSON::Syck (see https://metacpan.org/pod/XML::XML2JSON#module).

JSON::XS is used to parse the converted json, hence force XML2JSON to use JSON::XS so we are sure output is compatible.